### PR TITLE
Add study pages with mastery chart placeholders

### DIFF
--- a/src/app/wordbooks/[wordbookId]/study/dictation/page.tsx
+++ b/src/app/wordbooks/[wordbookId]/study/dictation/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { use } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+interface PageProps {
+  params: Promise<{ wordbookId: string }>;
+}
+
+export default function DictationPage({ params }: PageProps) {
+  const { wordbookId } = use(params);
+  return (
+    <div className="p-8 space-y-4">
+      <Link href={`/wordbooks/${wordbookId}/study`}>
+        <Button variant="outline">&larr; 返回</Button>
+      </Link>
+      <div className="flex flex-col items-center justify-center h-64 border rounded-md">
+        <p className="mb-4">Dictation Page - wordbook {wordbookId}</p>
+        <Button disabled>開始</Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/wordbooks/[wordbookId]/study/memorize/page.tsx
+++ b/src/app/wordbooks/[wordbookId]/study/memorize/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { use } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+interface PageProps {
+  params: Promise<{ wordbookId: string }>;
+}
+
+export default function MemorizePage({ params }: PageProps) {
+  const { wordbookId } = use(params);
+  return (
+    <div className="p-8 space-y-4">
+      <Link href={`/wordbooks/${wordbookId}/study`}>
+        <Button variant="outline">&larr; 返回</Button>
+      </Link>
+      <div className="flex flex-col items-center justify-center h-64 border rounded-md">
+        <p className="mb-4">Memorize Page - wordbook {wordbookId}</p>
+        <Button disabled>開始</Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/wordbooks/[wordbookId]/study/page.tsx
+++ b/src/app/wordbooks/[wordbookId]/study/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Link from "next/link";
+import { use, useEffect, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Chart,
+  ArcElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
+
+Chart.register(ArcElement, Tooltip, Legend);
+
+interface PageProps {
+  params: Promise<{ wordbookId: string }>;
+}
+
+export default function StudyPage({ params }: PageProps) {
+  const { wordbookId } = use(params);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const ctx = canvasRef.current?.getContext("2d");
+    if (!ctx) return;
+
+    const chart = new Chart(ctx, {
+      type: "doughnut",
+      data: {
+        labels: ["掌握", "未掌握"],
+        datasets: [
+          {
+            data: [70, 30],
+            backgroundColor: ["#4ade80", "#f87171"],
+          },
+        ],
+      },
+      options: {
+        plugins: {
+          legend: {
+            position: "bottom",
+          },
+        },
+      },
+    });
+
+    return () => {
+      chart.destroy();
+    };
+  }, []);
+
+  return (
+    <div className="p-8 space-y-6">
+      <div className="flex gap-4">
+        <Link href={`/wordbooks/${wordbookId}/study/memorize`}>
+          <Button>背單字</Button>
+        </Link>
+        <Link href={`/wordbooks/${wordbookId}/study/dictation`}>
+          <Button>默寫單字</Button>
+        </Link>
+      </div>
+      <div className="max-w-xs">
+        <canvas ref={canvasRef} />
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Add study main page for wordbooks with links to memorize and dictation and a placeholder mastery chart
- Create placeholder pages for memorize and dictation that retain wordbookId in dynamic routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf9fae9d588320a6bf9dbcc89b5339