### PR TITLE
feat: add memorize settings and study session

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import "@/i18n/i18n-client";
 import { AuthProvider } from "@/components/auth-provider";
 import { NavBar } from "@/components/nav-bar";
+import { StudyProvider } from "@/components/study/study-provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,10 +31,12 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {/* Wrap with AuthProvider so the entire app can use useAuth */}
+        {/* Wrap with providers so the entire app can use contexts */}
         <AuthProvider>
-          <NavBar />
-          {children}
+          <StudyProvider>
+            <NavBar />
+            {children}
+          </StudyProvider>
         </AuthProvider>
       </body>
     </html>

--- a/src/app/study/page.tsx
+++ b/src/app/study/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { FlashcardSession } from "@/components/study/FlashcardSession";
+
+export default function StudyPage() {
+  return <FlashcardSession />;
+}
+

--- a/src/components/study/FlashcardSession.tsx
+++ b/src/components/study/FlashcardSession.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useStudy } from "./study-provider";
+
+export function FlashcardSession() {
+  const { words } = useStudy();
+
+  if (!words.length) {
+    return <div className="p-8">No words selected.</div>;
+  }
+
+  return (
+    <div className="p-8 space-y-4">
+      {words.map((w) => (
+        <div key={w.id} className="border rounded p-4">
+          <div className="font-bold">{w.word}</div>
+          <div className="text-sm text-muted-foreground">{w.translation}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/src/components/study/MemorizeSettings.tsx
+++ b/src/components/study/MemorizeSettings.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { Word } from "@/lib/firestore-service";
+import { selectWords, StudyStrategy } from "@/lib/study";
+import { useStudy } from "./study-provider";
+
+interface MemorizeSettingsProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  words: Word[];
+}
+
+export function MemorizeSettings({
+  open,
+  onOpenChange,
+  words,
+}: MemorizeSettingsProps) {
+  const [count, setCount] = useState(10);
+  const [strategy, setStrategy] = useState<StudyStrategy>("random");
+  const { setWords } = useStudy();
+  const router = useRouter();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const selected = selectWords(words, count, strategy);
+    setWords(selected);
+    onOpenChange(false);
+    router.push("/study");
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <DialogHeader>
+            <DialogTitle>Study Settings</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="count">Number of Questions</Label>
+            <Input
+              id="count"
+              type="number"
+              min={1}
+              max={words.length}
+              value={count}
+              onChange={(e) => setCount(Number(e.target.value))}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Selection Strategy</Label>
+            <Select
+              value={strategy}
+              onValueChange={(v) => setStrategy(v as StudyStrategy)}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Strategy" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="random">Random</SelectItem>
+                <SelectItem value="mastery-high">High Mastery</SelectItem>
+                <SelectItem value="mastery-low">Low Mastery</SelectItem>
+                <SelectItem value="frequency-high">High Frequency</SelectItem>
+                <SelectItem value="frequency-low">Low Frequency</SelectItem>
+                <SelectItem value="created-newest">Newest</SelectItem>
+                <SelectItem value="created-oldest">Oldest</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <DialogFooter>
+            <Button type="submit">Start</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/components/study/study-provider.tsx
+++ b/src/components/study/study-provider.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+import type { Word } from "@/lib/firestore-service";
+
+interface StudyContextType {
+  words: Word[];
+  setWords: (w: Word[]) => void;
+}
+
+const StudyContext = createContext<StudyContextType | undefined>(undefined);
+
+export function StudyProvider({ children }: { children: ReactNode }) {
+  const [words, setWords] = useState<Word[]>([]);
+  return (
+    <StudyContext.Provider value={{ words, setWords }}>
+      {children}
+    </StudyContext.Provider>
+  );
+}
+
+export function useStudy() {
+  const ctx = useContext(StudyContext);
+  if (!ctx) {
+    throw new Error("useStudy must be used within a StudyProvider");
+  }
+  return ctx;
+}
+

--- a/src/components/words/word-list.tsx
+++ b/src/components/words/word-list.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Heart, Star, ChevronUp, ChevronDown } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { MemorizeSettings } from "@/components/study/MemorizeSettings";
 
 function masteryLevelMin(score: number) {
   if (score >= 90) return 90;
@@ -141,6 +142,7 @@ export function WordList({ wordbookId }: WordListProps) {
   const [bulkMode, setBulkMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [mounted, setMounted] = useState(false);
+  const [studyOpen, setStudyOpen] = useState(false);
   useEffect(() => {
     setMounted(true);
   }, []);
@@ -508,8 +510,14 @@ export function WordList({ wordbookId }: WordListProps) {
   }
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center gap-2">
+    <>
+      <MemorizeSettings
+        open={studyOpen}
+        onOpenChange={setStudyOpen}
+        words={words}
+      />
+      <div className="space-y-4">
+        <div className="flex items-center gap-2">
         {!bulkMode && (
         <Dialog open={createOpen} onOpenChange={(o) => {
           setCreateOpen(o);
@@ -663,7 +671,10 @@ export function WordList({ wordbookId }: WordListProps) {
         </Button>
         )}
         {!bulkMode && (
-        <Button className="bg-orange-500 text-black hover:bg-orange-600">
+        <Button
+          className="bg-orange-500 text-black hover:bg-orange-600"
+          onClick={() => setStudyOpen(true)}
+        >
           {t("wordList.studyWords")}
         </Button>
         )}
@@ -1188,6 +1199,7 @@ export function WordList({ wordbookId }: WordListProps) {
         </div>
       </div>
     </div>
+    </>
   );
 }
 

--- a/src/lib/study.ts
+++ b/src/lib/study.ts
@@ -1,0 +1,53 @@
+import type { Word } from "@/lib/firestore-service";
+
+export type StudyStrategy =
+  | "random"
+  | "mastery-high"
+  | "mastery-low"
+  | "frequency-high"
+  | "frequency-low"
+  | "created-newest"
+  | "created-oldest";
+
+export function selectWords(
+  words: Word[],
+  count: number,
+  strategy: StudyStrategy
+): Word[] {
+  const sorted = [...words];
+  switch (strategy) {
+    case "mastery-high":
+      sorted.sort((a, b) => (b.mastery || 0) - (a.mastery || 0));
+      break;
+    case "mastery-low":
+      sorted.sort((a, b) => (a.mastery || 0) - (b.mastery || 0));
+      break;
+    case "frequency-high":
+      sorted.sort((a, b) => (b.usageFrequency || 0) - (a.usageFrequency || 0));
+      break;
+    case "frequency-low":
+      sorted.sort((a, b) => (a.usageFrequency || 0) - (b.usageFrequency || 0));
+      break;
+    case "created-newest":
+      sorted.sort(
+        (a, b) =>
+          (b.createdAt?.toMillis() || 0) - (a.createdAt?.toMillis() || 0)
+      );
+      break;
+    case "created-oldest":
+      sorted.sort(
+        (a, b) =>
+          (a.createdAt?.toMillis() || 0) - (b.createdAt?.toMillis() || 0)
+      );
+      break;
+    case "random":
+    default:
+      for (let i = sorted.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [sorted[i], sorted[j]] = [sorted[j], sorted[i]];
+      }
+      break;
+  }
+  return sorted.slice(0, Math.min(count, sorted.length));
+}
+


### PR DESCRIPTION
## Summary
- implement flashcard study context and provider
- add memorize settings form with question count and selection strategies
- support word selection strategies and flashcard session page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfa1f24b3483209e7ac47567448c1c