### PR TITLE
feat: add flashcard study session

### DIFF
--- a/src/components/study/Flashcard.tsx
+++ b/src/components/study/Flashcard.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Word } from "@/lib/firestore-service";
+import { computeNextMastery, MasteryResponse } from "@/lib/compute-next-mastery";
+
+interface FlashcardProps {
+  word: Word;
+  onAnswer: (id: string, mastery: number) => void;
+}
+
+export function Flashcard({ word, onAnswer }: FlashcardProps) {
+  const [flipped, setFlipped] = useState(false);
+  const [answered, setAnswered] = useState(false);
+
+  useEffect(() => {
+    setFlipped(false);
+    setAnswered(false);
+  }, [word.id]);
+
+  const handleClick = (response: MasteryResponse) => {
+    if (answered) return;
+    const newScore = computeNextMastery(word.mastery || 0, response);
+    onAnswer(word.id, newScore);
+    setFlipped(true);
+    setAnswered(true);
+  };
+
+  return (
+    <div className="border p-6 rounded-lg text-center">
+      <div className="min-h-[120px] flex items-center justify-center mb-4">
+        {flipped ? (
+          <span className="text-2xl">{word.translation}</span>
+        ) : (
+          <span className="text-4xl font-bold">{word.word}</span>
+        )}
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <Button onClick={() => handleClick("unknown")} disabled={answered}>
+          陌生
+        </Button>
+        <Button onClick={() => handleClick("impression")} disabled={answered}>
+          有印象
+        </Button>
+        <Button onClick={() => handleClick("familiar")} disabled={answered}>
+          熟悉
+        </Button>
+        <Button onClick={() => handleClick("memorized")} disabled={answered}>
+          牢記
+        </Button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/study/FlashcardSession.tsx
+++ b/src/components/study/FlashcardSession.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { Word } from "@/lib/firestore-service";
+import { Flashcard } from "./Flashcard";
+import { Button } from "@/components/ui/button";
+
+interface FlashcardSessionProps {
+  words: Word[];
+}
+
+interface Result {
+  id: string;
+  mastery: number;
+}
+
+function shuffle<T>(arr: T[]): T[] {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+export function FlashcardSession({ words }: FlashcardSessionProps) {
+  const [order, setOrder] = useState<Word[]>(() => shuffle(words));
+  const [index, setIndex] = useState(0);
+  const [results, setResults] = useState<Result[]>([]);
+
+  const current = order[index];
+  const progress = (index / order.length) * 100;
+
+  const handleAnswer = (id: string, mastery: number) => {
+    setResults((prev) => [...prev, { id, mastery }]);
+    setTimeout(() => setIndex((prev) => prev + 1), 800);
+  };
+
+  const repeat = () => {
+    setIndex(0);
+    setResults([]);
+  };
+
+  const reshuffle = () => {
+    setOrder(shuffle(words));
+    setIndex(0);
+    setResults([]);
+  };
+
+  if (!order.length) {
+    return <p className="text-center">沒有題目</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="w-full h-2 bg-gray-200 rounded">
+        <div
+          className="h-full bg-blue-500 rounded"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+      {index < order.length ? (
+        <Flashcard word={current} onAnswer={handleAnswer} />
+      ) : (
+        <div className="text-center space-y-4">
+          <p>練習結束！</p>
+          <p className="text-sm text-gray-500">已回答 {results.length} 題</p>
+          <div className="flex gap-2 justify-center">
+            <Button onClick={repeat}>重複</Button>
+            <Button onClick={reshuffle}>重新抽題</Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/lib/compute-next-mastery.ts
+++ b/src/lib/compute-next-mastery.ts
@@ -1,0 +1,14 @@
+export type MasteryResponse = "unknown" | "impression" | "familiar" | "memorized";
+
+// Compute the next mastery score based on current score and user response.
+// The calculation nudges the mastery towards the target score of the selected response.
+export function computeNextMastery(current: number, response: MasteryResponse): number {
+  const targets: Record<MasteryResponse, number> = {
+    unknown: 0,
+    impression: 25,
+    familiar: 50,
+    memorized: 90,
+  };
+  const target = targets[response];
+  return Math.round((current + target) / 2);
+}


### PR DESCRIPTION
## Summary
- implement mastery progression utility for flashcards
- add interactive flashcard component with rating buttons
- introduce flashcard study session with progress bar and session controls

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch `Geist` from Google Fonts)

------
https://chatgpt.com/codex/tasks/task_e_68bfa44d6d608320b3ed1a50d3b98423