### PR TITLE
feat: update mastery after flashcard sessions

### DIFF
--- a/src/components/flashcard-session.tsx
+++ b/src/components/flashcard-session.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import { updateWordMastery, type Word } from "@/lib/firestore-service";
+import { Button } from "@/components/ui/button";
+
+interface FlashcardSessionProps {
+  userId: string;
+  wordbookId: string;
+  words: Word[];
+  onComplete?: () => void;
+}
+
+export function FlashcardSession({
+  userId,
+  wordbookId,
+  words,
+  onComplete,
+}: FlashcardSessionProps) {
+  const [index, setIndex] = useState(0);
+  const [results, setResults] = useState<Record<string, number>>({});
+
+  const handleAnswer = (wordId: string, mastery: number) => {
+    setResults((prev) => ({ ...prev, [wordId]: mastery }));
+    if (index + 1 < words.length) {
+      setIndex(index + 1);
+    } else {
+      finishSession({ ...results, [wordId]: mastery });
+    }
+  };
+
+  const finishSession = async (finalResults: Record<string, number>) => {
+    await Promise.all(
+      Object.entries(finalResults).map(([id, m]) =>
+        updateWordMastery(userId, wordbookId, id, m)
+      )
+    );
+    onComplete?.();
+  };
+
+  if (!words.length) {
+    return <p>No words to review.</p>;
+  }
+
+  const current = words[index];
+
+  return (
+    <div className="space-y-4">
+      <div className="text-xl font-semibold">{current.word}</div>
+      <div className="flex gap-2">
+        <Button
+          onClick={() =>
+            handleAnswer(current.id, Math.min(100, (current.mastery || 0) + 10))
+          }
+        >
+          I knew this
+        </Button>
+        <Button onClick={() => handleAnswer(current.id, current.mastery || 0)}>
+          I forgot
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/firestore-service.ts
+++ b/src/lib/firestore-service.ts
@@ -38,6 +38,7 @@ export interface Word {
   note: string;
   wordbookId: string;
   createdAt: Timestamp;
+  lastReviewed?: Timestamp | null;
 }
 
 // Custom part-of-speech tags
@@ -216,6 +217,30 @@ export const updateWord = async (
     wordId
   );
   await updateDoc(ref, updateData);
+};
+
+// Update mastery and last reviewed timestamp for a word
+export const updateWordMastery = async (
+  userId: string,
+  wordbookId: string,
+  wordId: string,
+  mastery: number
+): Promise<void> => {
+  const ref = doc(
+    db,
+    "users",
+    userId,
+    "wordbooks",
+    wordbookId,
+    "words",
+    wordId
+  );
+  const now = Timestamp.now();
+  await updateDoc(ref, { mastery, lastReviewed: now });
+
+  // Record review history
+  const reviewsRef = collection(ref, "reviews");
+  await addDoc(reviewsRef, { mastery, reviewedAt: now });
 };
 
 // Delete word


### PR DESCRIPTION
## Summary
- add `lastReviewed` to word records and helper to update mastery with review logs
- implement `FlashcardSession` component to batch update mastery at session end

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfa6799d8883209e97670f134a7fb2