### PR TITLE
fix: resolve TypeScript errors and add auth callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-next-env.d.ts
 
 #firebase
 .env.local

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
+/// <reference types="node" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/app/wordbooks/[wordbookId]/study/page.tsx
+++ b/src/app/wordbooks/[wordbookId]/study/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import Link from "next/link";
+import { use, useEffect, useState } from "react";
+import { useAuth } from "@/components/auth-provider";
+import { getWordsByWordbookId } from "@/lib/firestore-service";
+import { LanguageSwitcher } from "@/components/ui/language-switcher";
+import { Button } from "@/components/ui/button";
+import { signOut } from "firebase/auth";
+import { useTranslation } from "react-i18next";
+import { CircleProgress } from "@/components/ui/circle-progress";
+
+interface PageProps {
+  params: Promise<{ wordbookId: string }>;
+}
+
+export default function StudyPage({ params }: PageProps) {
+  const { wordbookId } = use(params);
+  const { user, auth } = useAuth();
+  const { t } = useTranslation();
+  const [overallMastery, setOverallMastery] = useState(0);
+  const [wordCount, setWordCount] = useState(0);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+    getWordsByWordbookId(user.uid, wordbookId).then((words) => {
+      setWordCount(words.length);
+      const mastery =
+        words.length > 0
+          ? words.reduce((sum, w) => sum + (w.mastery || 0), 0) / words.length
+          : 0;
+      setOverallMastery(mastery);
+    });
+  }, [user, wordbookId]);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const handleLogout = async () => {
+    await signOut(auth);
+  };
+
+  const masteryColor = `hsl(${(overallMastery / 100) * 120}, 80%, 45%)`;
+
+  return (
+    <div className="p-8 space-y-6">
+      <div className="flex items-center justify-between">
+        <Link
+          href={`/wordbooks/${wordbookId}`}
+          className="text-sm text-muted-foreground"
+          suppressHydrationWarning
+        >
+          &larr; {mounted ? t("backToList") : ""}
+        </Link>
+        <div className="flex items-center gap-2">
+          <LanguageSwitcher />
+          <Button variant="outline" onClick={handleLogout}>
+            <span suppressHydrationWarning>
+              {mounted ? t("logout") : ""}
+            </span>
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-col items-center gap-6">
+        <CircleProgress value={overallMastery} />
+        <div>{t("studyPage.totalWords", { count: wordCount })}</div>
+        <div className="flex items-center gap-2">
+          <span>{t("wordList.overallMastery")}</span>
+          <div className="h-2 w-40 rounded bg-gray-200">
+            <div
+              className="h-2 rounded"
+              style={{ width: `${overallMastery}%`, backgroundColor: masteryColor }}
+            />
+          </div>
+          <span>{overallMastery.toFixed(1)}%</span>
+        </div>
+        <div className="flex gap-4 mt-4">
+          <Button className="bg-orange-500 text-black hover:bg-orange-600">
+            {t("studyPage.recite")}
+          </Button>
+          <Button className="bg-green-500 text-black hover:bg-green-600">
+            {t("studyPage.dictation")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth-form.tsx
+++ b/src/components/auth-form.tsx
@@ -34,7 +34,11 @@ const formSchema = z.object({
     .min(6, { message: "Password must be at least 6 characters." }),
 });
 
-export function AuthForm() {
+interface AuthFormProps {
+  onSuccess?: () => void;
+}
+
+export function AuthForm({ onSuccess }: AuthFormProps) {
   const { t } = useTranslation();
   const [isLogin, setIsLogin] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
@@ -64,6 +68,7 @@ export function AuthForm() {
       }
       // On success, navigate to the home page or close the dialog
       console.log("Authentication successful!");
+      onSuccess?.();
     } catch (err: unknown) {
       // Check if err is an Error object
       if (err instanceof Error) {
@@ -85,6 +90,7 @@ export function AuthForm() {
     try {
       await signInWithPopup(auth, provider);
       console.log("Google login successful!");
+      onSuccess?.();
     } catch (err: unknown) {
       // Check if err is an Error object
       if (err instanceof Error) {

--- a/src/components/ui/circle-progress.tsx
+++ b/src/components/ui/circle-progress.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+interface CircleProgressProps {
+  value: number;
+  size?: number;
+  strokeWidth?: number;
+  color?: string;
+}
+
+export function CircleProgress({
+  value,
+  size = 200,
+  strokeWidth = 12,
+  color = "#facc15", // tailwind yellow-400
+}: CircleProgressProps) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference * (1 - value / 100);
+
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke="#e5e7eb" // gray-200
+        strokeWidth={strokeWidth}
+        fill="none"
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        stroke={color}
+        strokeWidth={strokeWidth}
+        fill="none"
+        strokeDasharray={`${circumference} ${circumference}`}
+        strokeDashoffset={offset}
+        strokeLinecap="round"
+        transform={`rotate(-90 ${size / 2} ${size / 2})`}
+      />
+      <text
+        x="50%"
+        y="50%"
+        dominantBaseline="middle"
+        textAnchor="middle"
+        className="text-3xl font-bold"
+      >
+        {value.toFixed(1)}%
+      </text>
+    </svg>
+  );
+}
+
+export default CircleProgress;

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -9,10 +9,9 @@ const Dialog = DialogPrimitive.Root;
 
 const DialogTrigger = DialogPrimitive.Trigger;
 
-const DialogPortal = ({
-  className,
-  ...props
-}: DialogPrimitive.DialogPortalProps) => <DialogPrimitive.Portal {...props} />;
+const DialogPortal = (props: DialogPrimitive.DialogPortalProps) => (
+  <DialogPrimitive.Portal {...props} />
+);
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,

--- a/src/components/words/word-list.tsx
+++ b/src/components/words/word-list.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Heart, Star, ChevronUp, ChevronDown } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import Link from "next/link";
 
 function masteryLevelMin(score: number) {
   if (score >= 90) return 90;
@@ -663,8 +664,13 @@ export function WordList({ wordbookId }: WordListProps) {
         </Button>
         )}
         {!bulkMode && (
-        <Button className="bg-orange-500 text-black hover:bg-orange-600">
-          {t("wordList.studyWords")}
+        <Button
+          className="bg-orange-500 text-black hover:bg-orange-600"
+          asChild
+        >
+          <Link href={`/wordbooks/${wordbookId}/study`}>
+            {t("wordList.studyWords")}
+          </Link>
         </Button>
         )}
         {bulkMode ? (

--- a/src/i18n/i18n-client.ts
+++ b/src/i18n/i18n-client.ts
@@ -40,6 +40,11 @@ i18n
             clear: "Empty Trash",
             clearing: "Clearing...",
           },
+          studyPage: {
+            recite: "Recite Words",
+            dictation: "Dictation",
+            totalWords: "Total words: {{count}}",
+          },
           backToList: "Back to wordbooks",
           wordbookList: {
             title: "My Wordbooks",
@@ -155,6 +160,11 @@ i18n
             clear: "清空垃圾桶",
             clearing: "清空中...",
           },
+          studyPage: {
+            recite: "背單字",
+            dictation: "默寫單字",
+            totalWords: "目前整體共{{count}}個單字",
+          },
           backToList: "返回單字本列表",
           wordbookList: {
             title: "我的單字本",
@@ -268,6 +278,11 @@ i18n
             empty: "ゴミ箱は空です",
             clear: "ゴミ箱を空にする",
             clearing: "消去中...",
+          },
+          studyPage: {
+            recite: "単語を暗記",
+            dictation: "単語を書き取り",
+            totalWords: "全体で{{count}}語",
           },
           backToList: "単語帳一覧に戻る",
           wordbookList: {

--- a/src/lib/firestore-service.ts
+++ b/src/lib/firestore-service.ts
@@ -56,7 +56,7 @@ export const getWordbooksByUserId = async (
   const querySnapshot = await getDocs(colRef);
   const wordbooks: Wordbook[] = [];
   querySnapshot.forEach((docSnap) => {
-    const data = docSnap.data() as Wordbook;
+    const data = docSnap.data() as Omit<Wordbook, "id">;
     if (!data.trashed) wordbooks.push({ id: docSnap.id, ...data });
   });
   return wordbooks;
@@ -114,7 +114,7 @@ export const getTrashedWordbooksByUserId = async (
   const snapshot = await getDocs(colRef);
   const wordbooks: Wordbook[] = [];
   snapshot.forEach((docSnap) => {
-    const data = docSnap.data() as Wordbook;
+    const data = docSnap.data() as Omit<Wordbook, "id">;
     if (data.trashed) wordbooks.push({ id: docSnap.id, ...data });
   });
   return wordbooks;
@@ -146,7 +146,8 @@ export const getWordbook = async (
   const ref = doc(db, "users", userId, "wordbooks", wordbookId);
   const snap = await getDoc(ref);
   if (!snap.exists()) return null;
-  return { id: snap.id, ...(snap.data() as Wordbook) };
+  const data = snap.data() as Omit<Wordbook, "id">;
+  return { id: snap.id, ...data };
 };
 
 // ------------------- Word CRUD -------------------

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "types": ["node"],
     "plugins": [
       {
         "name": "next"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,11 +14,12 @@
     "jsx": "preserve",
     "incremental": true,
     "types": ["node"],
+    "typeRoots": ["./node_modules/@types"],
     "plugins": [
-      {
-        "name": "next"
-      }
-    ],
+        {
+          "name": "next"
+        }
+      ],
     "paths": {
       "@/*": ["./src/*"],
       "firebase/*": ["./node_modules/firebase/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "firebase/*": ["./node_modules/firebase/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- allow AuthForm to invoke optional onSuccess callback after authentication
- simplify DialogPortal to satisfy Radix types
- avoid duplicate id property when building Wordbook objects from Firestore

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bfb8da3df88320a7f6b09b3966e98c