### PR TITLE
Handle Firebase auth during SSR

### DIFF
--- a/src/app/wordbooks/[wordbookId]/import/page.tsx
+++ b/src/app/wordbooks/[wordbookId]/import/page.tsx
@@ -37,6 +37,7 @@ export default function ImportPage({ params }: PageProps) {
   }, [user]);
 
   const handleLogout = async () => {
+    if (!auth) return;
     await signOut(auth);
   };
 
@@ -90,7 +91,7 @@ export default function ImportPage({ params }: PageProps) {
         <BackButton />
         <div className="flex items-center gap-2">
           <LanguageSwitcher />
-          <Button variant="outline" onClick={handleLogout}>
+          <Button variant="outline" onClick={handleLogout} disabled={!auth}>
             <span suppressHydrationWarning>{mounted ? t("logout") : ""}</span>
           </Button>
         </div>

--- a/src/app/wordbooks/[wordbookId]/page.tsx
+++ b/src/app/wordbooks/[wordbookId]/page.tsx
@@ -35,6 +35,7 @@ export default function WordbookPage({ params }: PageProps) {
   }, []);
 
   const handleLogout = async () => {
+    if (!auth) return;
     await signOut(auth);
   };
 
@@ -44,7 +45,7 @@ export default function WordbookPage({ params }: PageProps) {
         <BackButton />
         <div className="flex items-center gap-2">
           <LanguageSwitcher />
-          <Button variant="outline" onClick={handleLogout}>
+          <Button variant="outline" onClick={handleLogout} disabled={!auth}>
             <span suppressHydrationWarning>
               {mounted ? t("logout") : ""}
             </span>

--- a/src/app/wordbooks/[wordbookId]/srs/page.tsx
+++ b/src/app/wordbooks/[wordbookId]/srs/page.tsx
@@ -220,6 +220,7 @@ export default function SrsPage({ params }: PageProps) {
   }, [step, showAnswer]);
 
   const handleLogout = async () => {
+    if (!auth) return;
     await signOut(auth);
   };
 
@@ -230,7 +231,7 @@ export default function SrsPage({ params }: PageProps) {
           <BackButton />
           <div className="flex items-center gap-2">
             <LanguageSwitcher />
-            <Button variant="outline" onClick={handleLogout}>
+            <Button variant="outline" onClick={handleLogout} disabled={!auth}>
               {t("logout")}
             </Button>
           </div>
@@ -302,7 +303,7 @@ export default function SrsPage({ params }: PageProps) {
           <BackButton />
           <div className="flex items-center gap-2">
             <LanguageSwitcher />
-            <Button variant="outline" onClick={handleLogout}>
+            <Button variant="outline" onClick={handleLogout} disabled={!auth}>
               {t("logout")}
             </Button>
           </div>
@@ -320,7 +321,7 @@ export default function SrsPage({ params }: PageProps) {
           <BackButton />
           <div className="flex items-center gap-2">
             <LanguageSwitcher />
-            <Button variant="outline" onClick={handleLogout}>
+            <Button variant="outline" onClick={handleLogout} disabled={!auth}>
               {t("logout")}
             </Button>
           </div>
@@ -356,7 +357,7 @@ export default function SrsPage({ params }: PageProps) {
         </button>
         <div className="flex items-center gap-2">
           <LanguageSwitcher />
-          <Button variant="outline" onClick={handleLogout}>
+          <Button variant="outline" onClick={handleLogout} disabled={!auth}>
             {t("logout")}
           </Button>
         </div>

--- a/src/app/wordbooks/[wordbookId]/srs/stats/page.tsx
+++ b/src/app/wordbooks/[wordbookId]/srs/stats/page.tsx
@@ -59,6 +59,7 @@ export default function SrsStatsPage({ params }: PageProps) {
   const distChartRef = useRef<Chart | null>(null);
 
   const handleLogout = async () => {
+    if (!auth) return;
     await signOut(auth);
   };
 
@@ -203,7 +204,7 @@ export default function SrsStatsPage({ params }: PageProps) {
         <BackButton href={`/wordbooks/${wordbookId}`} />
         <div className="flex items-center gap-2">
           <LanguageSwitcher />
-          <Button variant="outline" onClick={handleLogout}>
+          <Button variant="outline" onClick={handleLogout} disabled={!auth}>
             {t("logout")}
           </Button>
         </div>

--- a/src/app/wordbooks/[wordbookId]/study/choice/page.tsx
+++ b/src/app/wordbooks/[wordbookId]/study/choice/page.tsx
@@ -61,6 +61,7 @@ export default function ChoiceSettingsPage({ params }: PageProps) {
   }, []);
 
   const handleLogout = async () => {
+    if (!auth) return;
     await signOut(auth);
   };
 
@@ -76,7 +77,7 @@ export default function ChoiceSettingsPage({ params }: PageProps) {
         <BackButton />
         <div className="flex items-center gap-2">
           <LanguageSwitcher />
-          <Button variant="outline" onClick={handleLogout}>
+          <Button variant="outline" onClick={handleLogout} disabled={!auth}>
             <span suppressHydrationWarning>
               {mounted ? t("logout") : ""}
             </span>

--- a/src/app/wordbooks/[wordbookId]/study/dictation/page.tsx
+++ b/src/app/wordbooks/[wordbookId]/study/dictation/page.tsx
@@ -61,6 +61,7 @@ export default function DictationSettingsPage({ params }: PageProps) {
   }, []);
 
   const handleLogout = async () => {
+    if (!auth) return;
     await signOut(auth);
   };
 
@@ -76,7 +77,7 @@ export default function DictationSettingsPage({ params }: PageProps) {
         <BackButton />
         <div className="flex items-center gap-2">
           <LanguageSwitcher />
-          <Button variant="outline" onClick={handleLogout}>
+          <Button variant="outline" onClick={handleLogout} disabled={!auth}>
             <span suppressHydrationWarning>
               {mounted ? t("logout") : ""}
             </span>

--- a/src/app/wordbooks/[wordbookId]/study/page.tsx
+++ b/src/app/wordbooks/[wordbookId]/study/page.tsx
@@ -49,6 +49,7 @@ export default function StudyPage({ params }: PageProps) {
   }, []);
 
   const handleLogout = async () => {
+    if (!auth) return;
     await signOut(auth);
   };
 
@@ -58,7 +59,7 @@ export default function StudyPage({ params }: PageProps) {
         <BackButton />
         <div className="flex items-center gap-2">
           <LanguageSwitcher />
-          <Button variant="outline" onClick={handleLogout}>
+          <Button variant="outline" onClick={handleLogout} disabled={!auth}>
             <span suppressHydrationWarning>
               {mounted ? t("logout") : ""}
             </span>

--- a/src/app/wordbooks/[wordbookId]/study/recite/page.tsx
+++ b/src/app/wordbooks/[wordbookId]/study/recite/page.tsx
@@ -58,6 +58,7 @@ export default function ReciteSettingsPage({ params }: PageProps) {
   }, []);
 
   const handleLogout = async () => {
+    if (!auth) return;
     await signOut(auth);
   };
 
@@ -73,7 +74,7 @@ export default function ReciteSettingsPage({ params }: PageProps) {
         <BackButton />
         <div className="flex items-center gap-2">
           <LanguageSwitcher />
-          <Button variant="outline" onClick={handleLogout}>
+          <Button variant="outline" onClick={handleLogout} disabled={!auth}>
             <span suppressHydrationWarning>
               {mounted ? t("logout") : ""}
             </span>

--- a/src/components/auth-form.tsx
+++ b/src/components/auth-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -10,6 +10,7 @@ import {
   createUserWithEmailAndPassword,
   signInWithPopup,
   GoogleAuthProvider,
+  Auth,
 } from "firebase/auth";
 // Previously: import { auth } from "@/lib/firebase";
 import { getFirebaseAuth } from "@/lib/firebase-client";
@@ -43,7 +44,11 @@ export function AuthForm({ onSuccess }: AuthFormProps) {
   const [isLogin, setIsLogin] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const auth = getFirebaseAuth();
+  const [auth, setAuth] = useState<Auth | null>(null);
+
+  useEffect(() => {
+    setAuth(getFirebaseAuth());
+  }, []);
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -57,6 +62,11 @@ export function AuthForm({ onSuccess }: AuthFormProps) {
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setIsLoading(true);
     setError(null);
+    if (!auth) {
+      setError("Authentication is not available.");
+      setIsLoading(false);
+      return;
+    }
     try {
       if (isLogin) {
         await signInWithEmailAndPassword(auth, values.email, values.password);
@@ -87,6 +97,11 @@ export function AuthForm({ onSuccess }: AuthFormProps) {
   async function handleGoogleLogin() {
     setIsLoading(true);
     setError(null);
+    if (!auth) {
+      setError("Authentication is not available.");
+      setIsLoading(false);
+      return;
+    }
     const provider = new GoogleAuthProvider();
     try {
       await signInWithPopup(auth, provider);

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -13,7 +13,7 @@ import { getFirebaseAuth } from "@/lib/firebase-client";
 interface AuthContextType {
   user: User | null;
   loading: boolean;
-  auth: Auth;
+  auth: Auth | null;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -25,13 +25,21 @@ interface AuthProviderProps {
 export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
-  const firebaseAuth = getFirebaseAuth();
+  const [firebaseAuth, setFirebaseAuth] = useState<Auth | null>(null);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(firebaseAuth, (currentUser) => {
+    const instance = getFirebaseAuth();
+    if (!instance) {
+      setLoading(false);
+      return;
+    }
+
+    setFirebaseAuth(instance);
+    const unsubscribe = onAuthStateChanged(instance, (currentUser) => {
       setUser(currentUser);
       setLoading(false);
     });
+
     return () => unsubscribe();
   }, []);
 

--- a/src/components/home-client.tsx
+++ b/src/components/home-client.tsx
@@ -32,6 +32,7 @@ export default function HomeClient() {
 
   const handleAuthSuccess = () => setIsAuthOpen(false);
   const handleLogout = async () => {
+    if (!auth) return;
     await signOut(auth);
   };
 
@@ -55,7 +56,7 @@ export default function HomeClient() {
             </p>
             <div className="flex items-center gap-2">
               <LanguageSwitcher />
-              <Button onClick={handleLogout} variant="outline">
+              <Button onClick={handleLogout} variant="outline" disabled={!auth}>
                 {t("logout")}
               </Button>
             </div>

--- a/src/lib/firebase-client.ts
+++ b/src/lib/firebase-client.ts
@@ -15,11 +15,16 @@ let auth: Auth | null = null;
  * Lazily obtain the Firebase Auth instance. This avoids initializing auth
  * during server-side builds where Firebase config may be missing.
  */
-export function getFirebaseAuth(): Auth {
+export function getFirebaseAuth(): Auth | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
   if (!auth) {
     auth = getAuth(firebaseApp);
     // Optional: set persistence and ignore failures
     setPersistence(auth, browserLocalPersistence).catch(() => {});
   }
+
   return auth;
 }


### PR DESCRIPTION
## Summary
- avoid initializing Firebase Auth when rendering on the server to prevent invalid API key errors during prerendering
- lazy load the auth instance in the provider and auth form so client-only code waits for the browser environment
- guard sign-out handlers throughout the app against a missing auth instance during initial render

## Testing
- `npm run lint` *(fails: missing dev dependencies due to registry access restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b356b7088320809d1fb31d546aa9