### PR TITLE
Fix dictation prompt display after submitting answer

### DIFF
--- a/src/app/wordbooks/[wordbookId]/srs/dictation/page.tsx
+++ b/src/app/wordbooks/[wordbookId]/srs/dictation/page.tsx
@@ -375,6 +375,7 @@ export default function SrsDictationPage({ params }: PageProps) {
       ? currentItem?.word.translation || ""
       : currentItem?.word.word || "";
   const answerChars = Array.from(currentAnswer);
+  const displayedPrompt = showDetails && result ? result.prompt : currentPrompt;
 
   const highlight = (text: string, target: string) => {
     if (!text || !target) return text;
@@ -575,7 +576,7 @@ export default function SrsDictationPage({ params }: PageProps) {
           />
         </div>
         <div className="border rounded p-6 space-y-4 text-center">
-          <div className="text-3xl font-bold mb-12">{currentPrompt}</div>
+          <div className="text-3xl font-bold mb-12">{displayedPrompt}</div>
           {!showDetails ? (
             <form onSubmit={submit} className="space-y-3">
               <label


### PR DESCRIPTION
## Summary
- keep the dictation prompt visible for the answered word while review details are shown
- derive the displayed prompt from the result to avoid jumping to the next question prematurely

## Testing
- npm run lint *(fails: missing dependency resolution because npm registry access is forbidden in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c90de6a9148320baaaa15b5b98fea0